### PR TITLE
Enable SPI2 for ENC28J60

### DIFF
--- a/arch/arm/boot/dts/ntc-gr8-crumb.dts
+++ b/arch/arm/boot/dts/ntc-gr8-crumb.dts
@@ -138,20 +138,20 @@
 };
 
 &spi2{
-       pinctrl-names = "default";
-       pinctrl-0 = <&spi2_pins_a>,
-                   <&spi2_cs0_pins_a>;
-       status = "okay";
-       spi2_0 {
-               #address-cells = <1>;
-               #size-cells = <0>;
-
-               compatible = "spidev";
-
-               reg = <0>;
-               spi-max-frequency = <50000000>;
-       };
- };
+  pinctrl-names = "default";
+  pinctrl-0 = <&spi2_pins_a>,
+              <&spi2_cs0_pins_a>;
+  status = "okay";
+  spi2_0 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    compatible = "microchip,enc28j60";
+    reg = <0>;
+    spi-max-frequency = <12000000>;
+    interrupt-parent = <&pio>;
+    interrupts = <6 13 IRQ_TYPE_EDGE_FALLING>;
+  };
+};
 
 
 &lradc {

--- a/arch/arm/boot/dts/ntc-gr8-crumb.dts
+++ b/arch/arm/boot/dts/ntc-gr8-crumb.dts
@@ -61,6 +61,7 @@
 		serial0 = &uart1;
 		serial1 = &uart2;
 		serial2 = &uart3;
+                spi2 = &spi2;
 	};
 
 	chosen {
@@ -135,6 +136,23 @@
 	pinctrl-0 = <&i2s0_data_pins_a>, <&i2s0_data_pins_a>;
 	status = "okay";
 };
+
+&spi2{
+       pinctrl-names = "default";
+       pinctrl-0 = <&spi2_pins_a>,
+                   <&spi2_cs0_pins_a>;
+       status = "okay";
+       spi2_0 {
+               #address-cells = <1>;
+               #size-cells = <0>;
+
+               compatible = "spidev";
+
+               reg = <0>;
+               spi-max-frequency = <50000000>;
+       };
+ };
+
 
 &lradc {
 	vref-supply = <&reg_ldo2>;

--- a/arch/arm/boot/dts/ntc-gr8.dtsi
+++ b/arch/arm/boot/dts/ntc-gr8.dtsi
@@ -741,7 +741,7 @@
 			dmas = <&dma SUN4I_DMA_DEDICATED 29>,
 			       <&dma SUN4I_DMA_DEDICATED 28>;
 			dma-names = "rx", "tx";
-			status = "disabled";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -909,6 +909,23 @@
 				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 			};
+
+			spi2_pins_a: spi2@0 {
+                                allwinner,pins = "PE1", "PE2", "PE3";
+                                allwinner,function = "spi2";
+                                allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+                                allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+                        };
+
+                        spi2_cs0_pins_a: spi2-cs0@0 {
+                                allwinner,pins = "PE0";
+                                allwinner,function = "spi2";
+                                allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+                                allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+                        };
+
+
+
 		};
 
 		pwm: pwm@01c20e00 {

--- a/arch/arm/boot/dts/sun5i-r8-chip.dts
+++ b/arch/arm/boot/dts/sun5i-r8-chip.dts
@@ -264,7 +264,6 @@
 	        allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 	        allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
 	};
-
 };
 
 &reg_dcdc2 {

--- a/arch/arm/boot/dts/sun5i-r8-chip.dts
+++ b/arch/arm/boot/dts/sun5i-r8-chip.dts
@@ -60,7 +60,6 @@
 		i2c2 = &i2c2;
 		serial0 = &uart1;
 		serial1 = &uart3;
-    spi2 = &spi2;
 	};
 
 	chosen {
@@ -266,28 +265,6 @@
 	        allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
 	};
 
-  spi2_pins_a: spi2@0 {
-    allwinner,pins = "PE1", "PE2", "PE3";
-    allwinner,function = "spi2";
-    allwinner,drive = <SUN4I_PINCTRL_10_MA>;
-    allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
-  };
-
-  spi2_cs0_pins_a: spi2_cs0@0 {
-    allwinner,pins = "PE0";
-    allwinner,function = "spi2";
-    allwinner,drive = <SUN4I_PINCTRL_10_MA>;
-    allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
-  };
-
-};
-
-/* Add support for SPI */
-&spi2{
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi2_pins_a>,
-		    <&spi2_cs0_pins_a>;
-	status = "okay";
 };
 
 &reg_dcdc2 {

--- a/arch/arm/boot/dts/sun5i-r8-chip.dts
+++ b/arch/arm/boot/dts/sun5i-r8-chip.dts
@@ -284,19 +284,10 @@
 
 /* Add support for SPI */
 &spi2{
-  pinctrl-names = "default";
-  pinctrl-0 = <&spi2_pins_a>,
-              <&spi2_cs0_pins_a>;
-  status = "okay";
-  spi2_0 {
-    #address-cells = <1>;
-    #size-cells = <0>;
-
-    compatible = "spidev";
-
-    reg = <0>;
-    spi-max-frequency = <50000000>;
-  };
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_pins_a>,
+		    <&spi2_cs0_pins_a>;
+	status = "okay";
 };
 
 &reg_dcdc2 {

--- a/arch/arm/boot/dts/sun5i-r8-chip.dts
+++ b/arch/arm/boot/dts/sun5i-r8-chip.dts
@@ -264,6 +264,38 @@
 	        allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 	        allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
 	};
+
+  spi2_pins_a: spi2@0 {
+    allwinner,pins = "PE1", "PE2", "PE3";
+    allwinner,function = "spi2";
+    allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+    allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+  };
+
+  spi2_cs0_pins_a: spi2_cs0@0 {
+    allwinner,pins = "PE0";
+    allwinner,function = "spi2";
+    allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+    allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+  };
+
+};
+
+/* Add support for SPI */
+&spi2{
+  pinctrl-names = "default";
+  pinctrl-0 = <&spi2_pins_a>,
+              <&spi2_cs0_pins_a>;
+  status = "okay";
+  spi2_0 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+
+    compatible = "spidev";
+
+    reg = <0>;
+    spi-max-frequency = <50000000>;
+  };
 };
 
 &reg_dcdc2 {

--- a/arch/arm/boot/dts/sun5i-r8-chip.dts
+++ b/arch/arm/boot/dts/sun5i-r8-chip.dts
@@ -60,6 +60,7 @@
 		i2c2 = &i2c2;
 		serial0 = &uart1;
 		serial1 = &uart3;
+    spi2 = &spi2;
 	};
 
 	chosen {


### PR DESCRIPTION
Also add additional GPIO interrupt to SPI2, required by ENC28J60.